### PR TITLE
Update modinfo.json

### DIFF
--- a/modinfo.json
+++ b/modinfo.json
@@ -7,5 +7,6 @@
     "github": "Moment.",
     "name": "Overhaul",
     "version": "0.01.1",
-    "website": "https://nkhook.github.io/"
+    "website": "https://nkhook.github.io/",
+    "load_order": "BASE"
 }


### PR DESCRIPTION
to fix for NKHook5 0.8.0.

load_order is required if you use MergeIgnore apparently